### PR TITLE
Fix storePath when not provided through command arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const Hapi = require('hapi')
 const storePath = argv.storePath || path.join(__dirname, 'uploads')
 
 if (!fs.existsSync(storePath)) {
-  console.log(`Creating store directory ${argv.storePath}`)
-  execSync(`mkdir -p ${argv.storePath}`)
+  console.log(`Creating store directory ${storePath}`)
+  execSync(`mkdir -p ${storePath}`)
 }
 
 const server = new Hapi.Server()


### PR DESCRIPTION
When the store path was not provided as a command line argument, it was failing to create the default directory as it was using `argv.storePath` for the path (`undefined`) instead of the correct default path.